### PR TITLE
feat: Add game over menu with restart and back buttons

### DIFF
--- a/game.html
+++ b/game.html
@@ -9,6 +9,11 @@
 <body>
     <div class="game-container">
         <canvas id="gameCanvas" width="288" height="512"></canvas>
+        <div id="gameOverMenu" class="hidden">
+            <h2>Game Over</h2>
+            <button id="restartButton">Restart</button>
+            <a href="index.html" class="button">Back to Home</a>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,7 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
+const gameOverMenu = document.getElementById('gameOverMenu');
+const restartButton = document.getElementById('restartButton');
 
 // Game variables
 let bird;
@@ -21,21 +23,14 @@ function setup() {
     pipes = [];
     score = 0;
     gameover = false;
-    // Add a pipe every 100 frames
     frames = 0;
+    gameOverMenu.classList.add('hidden');
 }
 
 function draw() {
     // Background
     ctx.fillStyle = "#70c5ce";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    if (gameover) {
-        ctx.fillStyle = "black";
-        ctx.font = "30px Arial";
-        ctx.fillText("Game Over", canvas.width / 2 - 80, canvas.height / 2);
-        return;
-    }
 
     // Bird
     ctx.fillStyle = "#fddb63";
@@ -58,7 +53,9 @@ function draw() {
 }
 
 function update() {
-    if (gameover) return;
+    if (gameover) {
+        return;
+    }
 
     // Bird
     bird.velocity += gravity;
@@ -78,9 +75,20 @@ function update() {
         pipes.shift();
     }
 
+    // Score
+    for (let i = 0; i < pipes.length; i++) {
+        let p = pipes[i];
+        if (p.x + p.width < birdX && !p.scored) {
+            score++;
+            p.scored = true;
+        }
+    }
+
+    frames++;
+
     // Collision detection
     // Ground
-    if (bird.y > canvas.height - 12) {
+    if (bird.y + 12 > canvas.height) { // bird radius is 12
         gameover = true;
     }
     // Pipes
@@ -92,17 +100,9 @@ function update() {
         }
     }
 
-    // Score
-    for (let i = 0; i < pipes.length; i++) {
-        let p = pipes[i];
-        if (p.x + p.width < birdX && !p.scored) {
-            score++;
-            p.scored = true;
-        }
+    if (gameover) {
+        gameOverMenu.classList.remove('hidden');
     }
-
-
-    frames++;
 }
 
 function gameLoop() {
@@ -113,22 +113,21 @@ function gameLoop() {
 
 document.addEventListener('keydown', function(event) {
     if (event.code === 'Space') {
-        if(gameover) {
-            setup();
-        } else {
+        if (!gameover) {
             bird.velocity = jump;
         }
     }
 });
 
 canvas.addEventListener('click', function(event) {
-    if(gameover) {
-        setup();
-    } else {
+    if (!gameover) {
         bird.velocity = jump;
     }
 });
 
+restartButton.addEventListener('click', function() {
+    setup();
+});
 
 setup();
 gameLoop();

--- a/style.css
+++ b/style.css
@@ -8,7 +8,44 @@ body {
 }
 
 .game-container {
+    position: relative;
     border: 1px solid #000;
+}
+
+#gameOverMenu {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: rgba(255, 255, 255, 0.8);
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+}
+
+#gameOverMenu h2 {
+    margin-top: 0;
+}
+
+#gameOverMenu button, #gameOverMenu .button {
+    display: inline-block;
+    padding: 10px 20px;
+    font-size: 18px;
+    color: white;
+    background-color: #4CAF50;
+    text-decoration: none;
+    border-radius: 5px;
+    border: none;
+    cursor: pointer;
+    margin: 5px;
+}
+
+#gameOverMenu button:hover, #gameOverMenu .button:hover {
+    background-color: #45a049;
+}
+
+.hidden {
+    display: none;
 }
 
 .home-container {


### PR DESCRIPTION
This commit introduces a game over menu that appears when the player loses. The menu provides options to either restart the game or return to the home page.

Changes include:
- Added a game over menu div to `game.html`, initially hidden.
- Styled the game over menu and its buttons in `style.css`.
- Updated `script.js` to show the menu upon game over.
- Added event listeners for the 'Restart' and 'Back to Home' buttons.
- Modified existing controls to only function when the game is active.